### PR TITLE
Escape spaces in path

### DIFF
--- a/wsl_hosts.ps1
+++ b/wsl_hosts.ps1
@@ -18,6 +18,8 @@ if (Test-Path "$configFolderPath\*.log") {
 
 $diskDrive = $configFolderPath.Substring(0,1);
 $configFolderPathWsl = $configFolderPath.Replace("$($diskDrive):\","/mnt/$($diskDrive.ToLower())/").Replace("\","/");
+# Escape spaces in the path. There may be spaces in user names unfortunately.
+$configFolderPathWsl = $configFolderPathWsl.Replace(" ","\ ");
 $outPutConfigPath = [PSCustomObject]@{
 	SCRIPT_PATH = $currentPathWin;
 };


### PR DESCRIPTION
In some unfortunate situations Windows user names may contain spaces. In such cases the script doesn't update .bashrc.

Replacing spaces fixes the problem.